### PR TITLE
refactoring of node-cef to support heka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 
 *~
+
+# Ignore vim swap files
+*.sw?

--- a/lib/cef.js
+++ b/lib/cef.js
@@ -12,6 +12,7 @@
  * Please see the README.md file for usage.
  */
 
+var console = require('console');
 const os = require('os');
 const syslog = require('./syslog');
 const Formatter = require('./formatter');
@@ -38,6 +39,7 @@ function ensureRequiredParams(config) {
       missing.push(option);
     }
   });
+
   return {config: config, missing: missing};
 }
 
@@ -66,7 +68,13 @@ var Logger = module.exports.Logger = function Logger(config) {
     }
   });
 
-  this.syslog = syslog.getInstance(syslogConfig);
+  this.err_back = config.err_back || this.err_back;
+
+  if (config.hasOwnProperty('log_factory')) {
+      this.syslog = config.log_factory(syslogConfig);
+  } else {
+      this.syslog = syslog.getInstance(syslogConfig);
+  }
 
   this.formatter = new Formatter(config);
 
@@ -95,6 +103,13 @@ Logger.prototype = {
     }
 
     return message;
+  },
+
+  err_back: function errback(data, context) {
+      console.error(data);
+      if (context !== null) {
+          console.error(context);
+      }
   },
 
   emergency: function emerg(params) {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -97,3 +97,4 @@ var validatorForKey = module.exports.validatorForKey = function validatorForKey 
   }
   return validators[info[1]];
 };
+

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,8 +1,33 @@
+/*
+ ***** BEGIN LICENSE BLOCK *****
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The Initial Developer of the Original Code is the Mozilla Foundation.
+ * Portions created by the Initial Developer are Copyright (C) 2012
+ * the Initial Developer. All Rights Reserved.
+ *
+ ***** END LICENSE BLOCK *****
+ */
+
 const util = require('util');
 const validatorForKey = require('./extensions').validatorForKey;
 
 const CURRENT_CEF_VERSION = "0";
 const requiredParams = ['vendor', 'product', 'version', 'signature', 'name', 'severity'];
+
+var console = require('console');
+
+const default_errback = function(data, context) {
+    // The default behavior is to just dump to stderr.
+    // Production enviroments will probably want to overload
+    // config.err_back
+    console.error(data);
+    if (context !== null) {
+        console.error(context);
+    }
+}
 
 var Formatter = module.exports = function Formatter(config) {
   config = config || {};
@@ -11,6 +36,9 @@ var Formatter = module.exports = function Formatter(config) {
   this.vendor = config.vendor || "";
   this.product = config.product || "";
   this.version = config.version || "";
+
+  // We allow an error-callback which is used when errors occur.
+  this.err_back = config.err_back || default_errback;
 
   return this;
 };
@@ -147,17 +175,19 @@ Formatter.prototype = {
     var extensionArray = [];
     var value = "";
     var validator = null;
-    Object.keys(extensions).forEach(function(key) {
+
+    var self = this;
+    Object.keys(extensions).forEach(function(key) { 
       validator = validatorForKey(key);
       if (validator) {
         value = extensions[key];
         if (validator(value)) {
           extensionArray.push(util.format("%s=%s", key, this.sanitizeExtensionValue(value)));
         } else {
-          console.error(util.format("Not a valid value for %s: %s", key, value));
+          self.err_back(util.format("Not a valid value for %s: %s", key, value));
         }
       } else {
-        console.error("Not a valid CEF or ArcSight key: " + key);
+          self.err_back("Not a valid CEF or ArcSight key: " + key);
       }
     }.bind(this));
     return extensionArray.join(" ");
@@ -248,7 +278,7 @@ Formatter.prototype = {
     // Build the CEF prefix
     var output = util.format("CEF:%s|%s|%s|%s|%s|%s|%s",
       CURRENT_CEF_VERSION,
-	  params.vendor,
+      params.vendor,
       params.product,
       params.version,
       params.signature,
@@ -257,8 +287,16 @@ Formatter.prototype = {
 
     // Add any extensions
     if (extensions) {
-      // The formatExtensions function will sanitize values
-      output += "|" + this.formatExtensions(extensions);
+        // The formatExtensions function will sanitize values
+        var ext_txt = this.formatExtensions(extensions);
+
+        // On error, just pass through the error-back and continue to
+        // format a message
+        if (ext_txt instanceof Error) {
+            this.err_back(ext_txt);
+        } else {
+            output += "|" + ext_txt;
+        }
     }
 
     // Be conservative and truncate strings over 1023 chars.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     { 
       "name": "Jed Parsons",
       "url": "https://github.com/jedp"
+    },
+    { 
+      "name": "Victor Ng",
+      "url": "https://github.com/crankycoder"
     }
   ],
 

--- a/tests/test_cef_formatter.js
+++ b/tests/test_cef_formatter.js
@@ -88,6 +88,7 @@ var suite = vows.describe("Formatter")
   }
 })
 
+
 .addBatch({
   "The format method": {
     topic: function() {
@@ -191,7 +192,88 @@ var suite = vows.describe("Formatter")
       }
     }
   }
+})
+
+.addBatch({
+    "Extension formatting": {
+        topic: function() {
+          var config = {
+            vendor: "Initech",
+            product: "Red Stapler",
+            version: "2",
+            err_back: function(data, ctx) {
+                this._global_error_back_data = data;
+                this._global_error_back_ctx = ctx;
+            }
+          };
+          return new Formatter(config);
+        },
+
+        "with invalid values": {
+            topic: function(formatter) {
+                var params = {
+                  name: "Low on staples",
+                  signature: "17",
+                  severity: 6,
+                  extensions: {
+                    rt: "20130320",
+                  }
+                };
+                return [formatter, formatter.format(params)];
+            },
+
+            "does not an error": function(err, result) {
+                assert(!err);
+                var formatter = result[0];
+                var log_txt = result[1];
+
+                var err_txt = "Not a valid value for rt: 20130320";
+                assert(formatter._global_error_back_data === err_txt);
+            }
+        }
+    }
+})
+
+.addBatch({
+    "Extension formatting": {
+        topic: function() {
+          var config = {
+            vendor: "Initech",
+            product: "Red Stapler",
+            version: "2",
+            err_back: function(data, ctx) {
+                this._global_error_back_data = data;
+                this._global_error_back_ctx = ctx;
+            }
+          };
+          return new Formatter(config);
+        },
+
+        "with invalid CEF or Arcsight keys": {
+            topic: function(formatter) {
+                var params = {
+                  name: "Low on staples",
+                  signature: "17",
+                  severity: 6,
+                  extensions: {
+                    fdsart: "Jun 12 2011 11:22:33",
+                  }
+                };
+                return [formatter, formatter.format(params)];
+            },
+
+            "does not throw an error": function(err, result) {
+                assert(!err);
+                var formatter = result[0];
+                var log_txt = result[1];
+
+                var err_txt = "Not a valid CEF or ArcSight key: fdsart";
+                assert(formatter._global_error_back_data === err_txt);
+            }
+        }
+    }
 });
+
 
 if (process.argv[1] === __filename) {
   suite.run();


### PR DESCRIPTION
This is the reworked patch to get heka-node and node-cef to play nice with each other.

I've added an error-back mechanism so that node-cef can pass errors back to something better than console.error. 

I've also added a property to the config so that a custom syslog factory can be provided which effectively gives us the ability to use heka as a transport instead of syslog.

Detailed changes:
- added test and code to catch extension errors
- added code and tests to support a custom error_back function to
  capture errors during CEF formatting.  Errors will be passed back
  through the error_back along with a context so that offline debugging
  is possible
- ignore vim swap files
- added test and code to pass in a custom log_factory through the
  syslogconfig object so that an alternate syslog-ish transport can be
  provided
